### PR TITLE
Fix pathlib requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ Click>=7.0
 Jinja2>=2.10.3
 numpy>=1.17.2
 pandas>=0.25.1
-pathlib==1.0.1
+pathlib==1.0.1; python_version < '3.8'
 pyhumps==1.3.1
 requests>=2.22.0
 wheel==0.33.4


### PR DESCRIPTION
pathlib is not required for higher python versions.
See: https://github.com/Kozea/WeasyPrint/issues/807